### PR TITLE
Use healthcheck instead of wait-for-it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,10 @@ jobs:
             command: |
                 set -x
                 docker-compose -f docker-compose.test.yml up -d
-                sleep 10
+                until curl --write-out %{http_code} --silent --output /dev/null http://localhost:8080/new | grep '^200$'
+                do
+                  sleep 5
+                done
         - run:
             name: Run e2e tests
             command: |


### PR DESCRIPTION
## Requirements

- [x] Pull request only makes one logical change
- [x] Changes have tests
- [x] All changes to deployment process have been documented fully

## What did you change?
Added healthcheck test to docker test of web service.

## Why did you change that?
Wait-for-it style sleeping doesn't always wait long enough.

## Deployment changes
None